### PR TITLE
Fixed Repo URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>F:\bteg\testserver\plugins</outputDirectory>
+                            <outputDirectory>${basedir}</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>${basedir}/target</directory>
@@ -95,7 +95,7 @@
         </repository>
         <repository>
             <id>nachwahl-repo</id>
-            <url>https://maven.nachwahl.dev/</url>
+            <url>https://mvn.robinferch.me/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
URL for nachwahl-repo was bad in the maven pom file, updated to newer version.